### PR TITLE
Process pipeline webhook requests in queue.

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"context"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/Suhaibshah22/pipeweaver/cmd"
 	"github.com/Suhaibshah22/pipeweaver/cmd/config"
@@ -14,15 +18,29 @@ func main() {
 		log.Fatalf("Failed to load application config: %v", err)
 	}
 
+	// Initialize Context
+	ctx, cancel := context.WithCancel(context.Background())
+
 	// Initialize DI container
-	container := cmd.InitializeContainer(cfg)
+	container := cmd.InitializeContainer(cfg, ctx)
+
+	// Initialize Signal Handling
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
 	// Initialize HTTP Router
 	router := cmd.SetupRouter(container)
 
-	//Start Server
-	address := ":" + cfg.Server.Port
-	if err := router.Run(address); err != nil {
-		log.Fatalf("Failed to start server: %v", err)
-	}
+	//Start Server in new goroutine
+	go func() {
+		address := ":" + cfg.Server.Port
+		if err := router.Run(address); err != nil {
+			log.Fatalf("Failed to start server: %v", err)
+		}
+	}()
+
+	<-sigChan
+	container.Logger.Info("Received termination signal. Shutting down gracefully...")
+	cancel()
+
 }


### PR DESCRIPTION
Added an internal application queue to process only one webhook request at a time. This is needed for the git operations to work correctly. 